### PR TITLE
Feature: Add Emote Insert Batching

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "@types/morgan": "^1.9.4",
     "@types/node-cron": "^3.0.7",
     "@types/pg": "^8.6.6",
-    "nodemon": "^2.0.20",
+    "nodemon": "^3.1.7",
     "prettier": "^2.8.3",
     "typescript": "^4.9.3"
   },
   "dependencies": {
-    "@kararty/dank-twitch-irc": "4.6.0",
+    "@kararty/dank-twitch-irc": "^6.2.0",
     "@types/ws": "^8.5.10",
     "chalk": "^5.2.0",
     "cors": "^2.8.5",

--- a/src/api/Routes/GET/Channel.ts
+++ b/src/api/Routes/GET/Channel.ts
@@ -22,7 +22,7 @@ async function handleChannelEmotes(req: Request, res: Response) {
 				message: 'Invalid limit parameter',
 			});
 		}
-
+    
 		const order = req.query.order as string;
 		if (order && !['asc', 'desc'].includes(order.toLowerCase())) {
 			return res.status(400).json({

--- a/src/database/Redis.ts
+++ b/src/database/Redis.ts
@@ -40,11 +40,11 @@ export class RedisClient {
 		return value;
 	}
 
-	async getArray(key: string): Promise<any[] | never[]> {
-		const value = await this._client.get(key);
+	async getEmotes(channelId: string): Promise<RedisEmote[] | never[]> {
+		const value = await this._client.get(`emotes:${channelId}`);
 		if (!value) return [];
 
-		return JSON.parse(value) ?? [];
+		return JSON.parse(value);
 	}
 
 	async getKeys(pattern: string): Promise<string[]> {

--- a/src/database/Redis.ts
+++ b/src/database/Redis.ts
@@ -40,11 +40,11 @@ export class RedisClient {
 		return value;
 	}
 
-	async getEmotes(channelId: string): Promise<RedisEmote[] | null> {
-		const value = await this._client.get(`emotes:${channelId}`);
-		if (!value) return null;
+	async getArray(key: string): Promise<any[] | never[]> {
+		const value = await this._client.get(key);
+		if (!value) return [];
 
-		return JSON.parse(value);
+		return JSON.parse(value) ?? [];
 	}
 
 	async getKeys(pattern: string): Promise<string[]> {

--- a/src/handler/EmoteHandler.ts
+++ b/src/handler/EmoteHandler.ts
@@ -1,28 +1,52 @@
 import type { PrivmsgMessage } from '@kararty/dank-twitch-irc';
 
-export async function EmoteHandler(msg: PrivmsgMessage): Promise<void> {
-	const get = (await Bot.Redis.getEmotes(msg.channelID)) ?? [];
-	const emotesUsedByNames: Record<string, [string, string, number]> = {};
+type AccumulatedBatch = [string, string, number][]; // [channelID, id, count]
 
-	msg.messageText.split(/\s/g).forEach((word) => {
-		get.forEach((emote) => {
-			const emoteName = emote.alias === emote.name ? emote.name : emote.alias;
-			if (emoteName === word) {
-				emotesUsedByNames[emote.name] ||= [emote.alias, emote.id, 0];
-				emotesUsedByNames[emote.name][2]++;
+export class EmoteHandler {
+	private static instance: EmoteHandler;
+
+	private readonly batchSize: number;
+	private readonly accumulation: AccumulatedBatch;
+
+	constructor() {
+		if (EmoteHandler.instance) {
+			throw new Error('Use EmoteHandler.New() to get an instance of EmoteHandler');
+		}
+
+		this.batchSize = Bot.Config.BatchSize ?? 100;
+		this.accumulation = [];
+	}
+
+	static New(): EmoteHandler {
+		if (!this.instance) {
+			this.instance = new EmoteHandler();
+		}
+
+		return this.instance;
+	}
+
+	public async handleEmote(msg: PrivmsgMessage): Promise<void> {
+		const get = await Bot.Redis.getArray(`emotes:${msg.channelID}`);
+		const emoteNameMap: Map<string, [string, string, number]> = new Map();
+	
+		for (const word of msg.messageText.split(' ')) {
+			for (const emote of get) {
+				const usedAlias = emote.alias === emote.name ? emote.name : emote.alias;
+				if (usedAlias === word) {
+					if (!emoteNameMap.has(emote.name)) {
+						emoteNameMap.set(emote.name, [emote.alias, emote.id, 0]);
+					}
+	
+					emoteNameMap.get(emote.name)![2]++;
+				}
 			}
-		});
-	});
-
-	if (Object.entries(emotesUsedByNames).length > 0) {
-		for (const [name, [emoteAlias, id, count]] of Object.entries(emotesUsedByNames)) {
-			const alias = name == emoteAlias ? null : emoteAlias;
-			await Bot.SQL.Query(`UPDATE emotes SET emote_count = emotes.emote_count + $1 WHERE emotes.twitch_id = $2 AND emotes.emote_id = $3`, [
-				count,
-				msg.channelID,
-				id,
-			]);
-
+		}
+	
+		if (emoteNameMap.size === 0) return;
+	
+		for (const [name, [alias, id, count]] of emoteNameMap.entries()) {
+			this.accumulate(msg.channelID, id, count);
+	
 			Bot.WS.Send(msg.channelID, {
 				type: 'emote',
 				channelName: msg.channelName,
@@ -36,9 +60,68 @@ export async function EmoteHandler(msg: PrivmsgMessage): Promise<void> {
 					count,
 				},
 			});
-
-			Bot.Logger.Debug(`Emote ${name} (${id}) used ${count} times in ${msg.channelName}`);
-			Bot.Logger.Debug(`${process.memoryUsage().rss / 1024 / 1024} MB, ${process.memoryUsage().heapUsed / 1024 / 1024} MB`);
+	
+			Bot.Logger.Debug(
+				`Emote ${name} (${id}) used ${count} times in ${msg.channelName}` +
+				` - Accumulation: ${this.accumulation.length}`
+			);
+	
+			Bot.Logger.Debug(
+				`${process.memoryUsage().rss / 1024 / 1024} MB` +
+				`, ${process.memoryUsage().heapUsed / 1024 / 1024} MB`
+			);
 		}
+	}
+	
+  private async accumulate(channelID: string, id: string, count: number): Promise<void> {
+		this.accumulation.push([channelID, id, count]);
+	
+		if (this.accumulation.length < this.batchSize) return;
+		
+		const batchData = new Map<string, number>();
+	
+		for (const [channelID, emoteID, count] of this.accumulation) {
+			const key = `${channelID}:${emoteID}`;
+			batchData.set(key, (batchData.get(key) ?? 0) + count);
+		}
+	
+		this.accumulation.length = 0; 
+	
+		const twitchIDs: string[] = [];
+		const emoteIDs: string[] = [];
+		const counts: number[] = [];
+	
+		for (const [key, count] of batchData.entries()) {
+			const [channelID, emoteID] = key.split(':');
+			twitchIDs.push(channelID);
+			emoteIDs.push(emoteID);
+			counts.push(count);
+		}
+	
+		Bot.Logger.Debug(`Inserting batch of ${twitchIDs.length} 7TV emotes into the database`);
+		
+		const t1 = performance.now();
+		const values = [twitchIDs, emoteIDs, counts];
+		const query = 
+			`UPDATE emotes 
+			 SET emote_count = emote_count + data.count
+			 FROM (SELECT UNNEST($1::VARCHAR[]) AS twitch_id, 
+										UNNEST($2::VARCHAR[]) AS emote_id, 
+										UNNEST($3::INT[]) AS count) AS data
+			 WHERE emotes.twitch_id = data.twitch_id
+			 AND emotes.emote_id = data.emote_id;`
+
+		const result = await Bot.SQL.Query(query, values);
+		const t2 = performance.now();
+		const duration = (t2 - t1).toFixed(2);
+		if (result.rowCount !== twitchIDs.length) {
+			return Bot.Logger.Error(
+				`Failed to insert batch of emotes into the database - Took: ${duration}ms`
+			);
+		} 
+
+		Bot.Logger.Debug(
+			`Batch of ${twitchIDs.length} 7TV emotes inserted into the database - Took: ${duration}ms`
+		);
 	}
 }

--- a/src/handler/EmoteHandler.ts
+++ b/src/handler/EmoteHandler.ts
@@ -26,7 +26,7 @@ export class EmoteHandler {
 	}
 
 	public async handleEmote(msg: PrivmsgMessage): Promise<void> {
-		const get = await Bot.Redis.getArray(`emotes:${msg.channelID}`);
+		const get = await Bot.Redis.getEmotes(msg.channelID);
 		const emoteNameMap: Map<string, [string, string, number]> = new Map();
 	
 		for (const word of msg.messageText.split(' ')) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,26 +9,29 @@ import { WebsocketServer } from './manager/WebSocketManager.js';
 import { ChannelEmoteManager } from './manager/ChannelEmoteManager.js';
 import { Cronjob } from './utility/Cronjob.js';
 import { IVR } from './services/IVR.js';
+import { EmoteHandler } from './handler/EmoteHandler.js';
+import { GlobalClasses } from './types/types.js';
 import { GetChannelsInfo } from './services/SevenTV.js';
 import { EventAPI } from './services/EventAPI.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const configPath = path.resolve(__dirname, 'config.json');
 
-// @ts-ignore
-global.Bot = {};
-// @ts-ignore
+let Bot = global.Bot = {} as GlobalClasses;
+
+// @ts-expect-error CBA to fix top level await in tsconfig
 Bot.Config = JSON.parse(await fs.readFile(configPath, 'utf-8'));
 Bot.Logger = Logger.New();
 Bot.Twitch = new ChatClient();
 Bot.Redis = RedisClient.New();
 Bot.WS = new WebsocketServer(Bot.Config.WS.port);
 Bot.Cronjob = Cronjob.New();
+Bot.EmoteHandler = EmoteHandler.New();
 Bot.EventAPI = EventAPI.New();
 
 (async () => {
 	await Postgres.Setup();
-	// @ts-ignore
+
 	Bot.SQL = Postgres.New();
 	await Bot.SQL.CreateTables();
 

--- a/src/services/TwitchClient.ts
+++ b/src/services/TwitchClient.ts
@@ -1,7 +1,6 @@
 import 'reflect-metadata';
 import { ChatClient as TwitchIRC } from '@kararty/dank-twitch-irc';
 import { singleton } from 'tsyringe';
-import { EmoteHandler } from '../handler/EmoteHandler.js';
 import { CommandHandler } from '../handler/CommandHandler.js';
 
 @singleton()
@@ -43,7 +42,7 @@ export class ChatClient extends TwitchIRC {
 		});
 
 		this.on('PRIVMSG', (msg) => {
-			EmoteHandler(msg);
+			Bot.EmoteHandler.handleEmote(msg);
 			CommandHandler(msg);
 		});
 	}

--- a/src/services/TwitchClient.ts
+++ b/src/services/TwitchClient.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { ChatClient as TwitchIRC } from '@kararty/dank-twitch-irc';
+import { JoinRateLimiter, ChatClient as TwitchIRC } from '@kararty/dank-twitch-irc';
 import { singleton } from 'tsyringe';
 import { CommandHandler } from '../handler/CommandHandler.js';
 
@@ -12,8 +12,6 @@ export class ChatClient extends TwitchIRC {
 			rateLimits: 'verifiedBot',
 			ignoreUnhandledPromiseRejections: true,
 		});
-
-		this.connect();
 
 		this.on('error', (err) => {
 			Bot.Logger.Error(err);
@@ -45,6 +43,10 @@ export class ChatClient extends TwitchIRC {
 			Bot.EmoteHandler.handleEmote(msg);
 			CommandHandler(msg);
 		});
+
+		this.use(new JoinRateLimiter(this));
+
+		this.connect();
 	}
 
 	Join(channel: string): void {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,16 +1,7 @@
-import { Config } from './types';
+import { Config, GlobalClasses } from './types';
 
 declare global {
-	var Bot: {
-		Config: Config;
-		Twitch: import('../services/TwitchClient').ChatClient;
-		SQL: import('../database/Postgres').Postgres;
-		Redis: import('../database/Redis').RedisClient;
-		Logger: import('../utility/Logger').Logger;
-		EventAPI: import('../services/EventAPI').EventAPI;
-		WS: import('../manager/WebSocketManager').WebsocketServer;
-		Cronjob: import('../utility/Cronjob').Cronjob;
-	};
+	var Bot: GlobalClasses;
 }
 
 export {};

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -22,6 +22,7 @@ export type Config = {
 		port: number;
 	};
 	Admins: string[];
+	BatchSize: number;
 };
 
 export type NewEmote = {
@@ -39,3 +40,19 @@ export type UpdateEmote = {
 	channelId: string;
 	channelName: string;
 };
+
+export type IChannels = {
+	count: number;
+};
+
+export interface GlobalClasses {
+	Config: Config;
+	Twitch: import('../services/TwitchClient').ChatClient;
+	SQL: import('../database/Postgres').Postgres;
+	Redis: import('../database/Redis').RedisClient;
+	Logger: import('./utils/Logger').Logger;
+  EventAPI: import('../services/EventAPI').EventAPI;
+	WS: import('./services/Websocket').Websocket;
+	Cronjob: import('../utility/Cronjob').Cronjob;
+	EmoteHandler: import('../handler/EmoteHandler').EmoteHandler;
+}


### PR DESCRIPTION
Changes proposed:

- Batch inserts of emotes to atomize queries.
- Use maps instead of objects for incrementing and deduplicating emotes.
- Couple minor changes to types.
- Emote handler to singleton pattern.
- New config value for batch size, default 100
- Unrelated - Use JoinRateLimiter mixin for dank-twitch-irc

I did minor testing and it seemed to update correctly.

![image](https://github.com/user-attachments/assets/a942f266-fa84-42d8-afd5-3e2fdd1deb43)

